### PR TITLE
Fixes bugs with computer names

### DIFF
--- a/Templates/customizations.xml
+++ b/Templates/customizations.xml
@@ -12,7 +12,7 @@
       <Common>
         <!--Accounts>
           <ComputerAccount>
-            <ComputerName>{OEMNAME}{Product}</ComputerName>
+            <ComputerName>{Product}</ComputerName>
           </ComputerAccount>
         </Accounts-->
         <Policies>

--- a/Templates/customizations_RS2.xml
+++ b/Templates/customizations_RS2.xml
@@ -10,11 +10,11 @@
   <Settings xmlns="urn:schemas-microsoft-com:windows-provisioning">
     <Customizations>
       <Common>
-        <Accounts>
+        <!--<Accounts>
           <ComputerAccount>
-            <ComputerName>{OEMNAME}{Product}</ComputerName>
+            <ComputerName>{Product}</ComputerName>
           </ComputerAccount>
-        </Accounts>
+        </Accounts>-->
         <ApplicationManagement>
           <AllowAppStoreAutoUpdate>Allowed</AllowAppStoreAutoUpdate>
         </ApplicationManagement>


### PR DESCRIPTION
* Removes the custom computer name from the RaspberryPi template, this now matches the other architectures
* Updates (commented out) computer names to just {Product} to decrease likelihood anyone will run into the 15 character limit computer name issue