### PR TITLE
Fixing ICD.exe parameters : Remove Common-Provisioning.dat

### DIFF
--- a/Tools/LaunchTool.cmd
+++ b/Tools/LaunchTool.cmd
@@ -25,14 +25,14 @@ if %wowRegKeyPathFound% EQU 0 (
   if %regKeyPathFound% EQU 0 (
     echo.%CLRRED%Error:No Windows Kits found. Install ADK.%CLREND%
     pause
-    exit /b 
+    exit /b
   ) else (
     set regKeyPath=HKLM\Software\Microsoft\Windows Kits\Installed Roots
   )
 ) else (
     set regKeyPath=HKLM\Software\Wow6432Node\Microsoft\Windows Kits\Installed Roots
 )
-  
+
 for /F "skip=2 tokens=2*" %%i in ('REG QUERY "%regKeyPath%" /v %KitsRootRegValueName%') do (SET KITPATH=%%jAssessment and Deployment Kit\Deployment Tools)
 REM Cleanup local variables
 set regKeyPathFound=
@@ -62,10 +62,11 @@ REM Check for WDK Presence
 if exist "%KITSROOT%\CoreSystem" (
     dir /B /AD "%KITSROOT%CoreSystem" > %IOTADK_ROOT%\wdkversion.txt
     set /P WDK_VERSION=<%IOTADK_ROOT%\wdkversion.txt
-    (
-        for /f "tokens=3 delims=." %%A in ("%WDK_VERSION%") do ( set WDK_VERSION=%%A )
-    )
     del %IOTADK_ROOT%\wdkversion.txt
+)
+
+if defined WDK_VERSION (
+    for /f "tokens=3 delims=." %%A in ("%WDK_VERSION%") do ( set WDK_VERSION=%%A )
 ) else (
     set WDK_VERSION=NotFound
 )
@@ -89,7 +90,6 @@ if exist "%KITSROOT%\MSPackages" (
     )
     del %IOTADK_ROOT%\corekitversion.txt
 ) else (
-    set KIT_VERSION=NotFound
     set COREKIT_VER=NotFound
     echo.%CLRYEL%Warning : Core kit packages not found. Image creation will fail.%CLREND%
 )

--- a/Tools/createprovpkg.cmd
+++ b/Tools/createprovpkg.cmd
@@ -30,7 +30,7 @@ set STORE_DIR=%KITSROOT%\Assessment and Deployment Kit\Imaging and Configuration
 
 echo Creating Provisioning Package using %1
 cd %~dp1
-call icd.exe /Build-ProvisioningPackage /CustomizationXML:"%1" /PackagePath:%2 /StoreFile:"%STORE_DIR%\Microsoft-IoTUAP-Provisioning.dat,%STORE_DIR%\Microsoft-Common-Provisioning.dat" +Overwrite /Variables:"BSPVER=%PKG_VER%"
+call icd.exe /Build-ProvisioningPackage /CustomizationXML:"%1" /PackagePath:%2 /StoreFile:"%STORE_DIR%\Microsoft-IoTUAP-Provisioning.dat" +Overwrite /Variables:"BSPVER=%PKG_VER%"
 if errorlevel 1 goto Error
 
 goto End


### PR DESCRIPTION
Fixing ICD.exe parameters : Remove Common-Provisioning.dat
and some small fixes in the version display.