### PR TITLE
remove GUID change in script

### DIFF
--- a/Tools/GetPartitionInfo.ps1
+++ b/Tools/GetPartitionInfo.ps1
@@ -40,20 +40,12 @@ Foreach ($Partition in $Partitions)
     $ParFS=$Partition.FileSystem;
     $ParDrive='-';
     if(!$ParSize){ $ParSize=0;}
-    if(!$ParFS)
-    {
-        $ParFS="NA";
-        if ( $guids -contains "$ParType") {
-            $ParDrive= GetFreeDriveLetter;
-            $drivesinuse+= $ParDrive;
-        }
-    }
-    else
-    {
-        $ParDrive=GetFreeDriveLetter;
+    if(!$ParFS){ $ParFS="NA";}
+    if ( $guids -contains "$ParType") {
+        $ParDrive= GetFreeDriveLetter;
         $drivesinuse+= $ParDrive;
     }
-
     Write-Host "$ParName,$count,$ParType,$ParSize,$ParFS,$ParDrive";
     $count= $count + 1;
-}
+} 
+

--- a/Tools/partitioninfo.cmd
+++ b/Tools/partitioninfo.cmd
@@ -202,17 +202,7 @@ for /f "tokens=1,2 delims=, " %%i in (%2) do (
         exit /b 1
     )
     call :PRINT_TEXT "sel par !PARID_%%i!"
-    if /I [%3] == [assign] ( 
-        if /I [!TYPE_%%i!] NEQ [%GUID_SYSTEM%] if /I [!TYPE_%%i!] NEQ [%GUID_BASIC_DATA%] (
-            call :PRINT_TEXT "set id=%GUID_BASIC_DATA%"
-        )
-    )
     call :PRINT_TEXT "%3 letter=%%j noerr"
-    if /I [%3] == [remove] (
-        if /I [!TYPE_%%i!] NEQ [%GUID_SYSTEM%] if /I [!TYPE_%%i!] NEQ [%GUID_BASIC_DATA%] (
-            call :PRINT_TEXT "set id=!TYPE_%%i!"
-        )
-    )
     echo.>> "%OUTFILE%"
 )
 call :PRINT_TEXT "lis vol"


### PR DESCRIPTION
Changing the GUID for certain partitions can cause boot failures if there is a power loss during recovery.
 Removing this logic from the script for now to prevent this from happening.