### PR TITLE
Removing deprecated features from oeminputxml files

### DIFF
--- a/Source-arm/BSP/CustomRpi2/OEMInputSamples/TestOEMInput.xml
+++ b/Source-arm/BSP/CustomRpi2/OEMInputSamples/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-arm/BSP/QCDB410C/OEMInputSamples/RetailOEMInput.xml
+++ b/Source-arm/BSP/QCDB410C/OEMInputSamples/RetailOEMInput.xml
@@ -37,7 +37,6 @@
       <Feature>IOT_EFIESP</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_CP210x_MAKERDRIVER</Feature>
       <Feature>IOT_FTSER2K_MAKERDRIVER</Feature>

--- a/Source-arm/BSP/QCDB410C/OEMInputSamples/TestOEMInput.xml
+++ b/Source-arm/BSP/QCDB410C/OEMInputSamples/TestOEMInput.xml
@@ -41,7 +41,6 @@
       <Feature>IOT_KDUSB_SETTINGS</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_GENERIC_POP</Feature> 
       <Feature>IOT_APPLICATIONS</Feature>
@@ -57,7 +56,6 @@
       <Feature>IOT_DIRECTX_TOOLS</Feature>
       <Feature>IOT_ALLJOYN_APP</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_CRT140</Feature>
       <Feature>IOT_BERTHA</Feature>
       <Feature>IOT_APP_TOOLKIT</Feature>

--- a/Source-arm/BSP/Rpi2/OEMInputSamples/TestOEMInput.xml
+++ b/Source-arm/BSP/Rpi2/OEMInputSamples/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-arm/Products/DigitalSign/TestOEMInput.xml
+++ b/Source-arm/Products/DigitalSign/TestOEMInput.xml
@@ -66,7 +66,6 @@
       <Feature>IOT_POWERSHELL</Feature>
       <Feature>IOT_DIRECTX_TOOLS</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_CRT140</Feature>
       <Feature>IOT_APP_TOOLKIT</Feature>
       <Feature>IOT_CP210x_MAKERDRIVER</Feature>

--- a/Source-arm/Products/MultiLangSample/TestOEMInput.xml
+++ b/Source-arm/Products/MultiLangSample/TestOEMInput.xml
@@ -68,7 +68,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-arm/Products/RecoverySample/RetailOEMInput.xml
+++ b/Source-arm/Products/RecoverySample/RetailOEMInput.xml
@@ -37,7 +37,6 @@
       <Feature>IOT_EFIESP</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_CP210x_MAKERDRIVER</Feature>
       <Feature>IOT_FTSER2K_MAKERDRIVER</Feature>

--- a/Source-arm/Products/RecoverySample/TestOEMInput.xml
+++ b/Source-arm/Products/RecoverySample/TestOEMInput.xml
@@ -41,7 +41,6 @@
       <Feature>IOT_KDUSB_SETTINGS</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_GENERIC_POP</Feature>
       <Feature>IOT_APPLICATIONS</Feature>
@@ -57,7 +56,6 @@
       <Feature>IOT_DIRECTX_TOOLS</Feature>
       <Feature>IOT_ALLJOYN_APP</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_CRT140</Feature>
       <Feature>IOT_BERTHA</Feature>
       <Feature>IOT_APP_TOOLKIT</Feature>

--- a/Source-arm/Products/SampleA/TestOEMInput.xml
+++ b/Source-arm/Products/SampleA/TestOEMInput.xml
@@ -52,7 +52,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-arm/Products/SampleB/TestOEMInput.xml
+++ b/Source-arm/Products/SampleB/TestOEMInput.xml
@@ -52,7 +52,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-arm/Products/SecureSample/RetailOEMInput.xml
+++ b/Source-arm/Products/SecureSample/RetailOEMInput.xml
@@ -37,7 +37,6 @@
       <Feature>IOT_EFIESP</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_CP210x_MAKERDRIVER</Feature>
       <Feature>IOT_FTSER2K_MAKERDRIVER</Feature>

--- a/Source-arm/Products/SecureSample/TestOEMInput.xml
+++ b/Source-arm/Products/SecureSample/TestOEMInput.xml
@@ -41,7 +41,6 @@
       <Feature>IOT_KDUSB_SETTINGS</Feature>
       <Feature>IOT_EFIESP_BCD</Feature>
       <Feature>IOT_DISABLEBASICDISPLAYFALLBACK</Feature>
-      <Feature>IOT_HWN_CLASS_EXTENSION</Feature>
       <Feature>IOT_USBFN_CLASS_EXTENSION</Feature>
       <Feature>IOT_GENERIC_POP</Feature>
       <Feature>IOT_APPLICATIONS</Feature>
@@ -57,7 +56,6 @@
       <Feature>IOT_DIRECTX_TOOLS</Feature>
       <Feature>IOT_ALLJOYN_APP</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_CRT140</Feature>
       <Feature>IOT_BERTHA</Feature>
       <Feature>IOT_APP_TOOLKIT</Feature>

--- a/Source-arm/Products/SingleLangSample/TestOEMInput.xml
+++ b/Source-arm/Products/SingleLangSample/TestOEMInput.xml
@@ -54,7 +54,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/BSP/CustomMBMx64/OEMInputSamples/TestOEMInput.xml
+++ b/Source-x64/BSP/CustomMBMx64/OEMInputSamples/TestOEMInput.xml
@@ -54,7 +54,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/BSP/MBMx64/OEMInputSamples/TestOEMInput.xml
+++ b/Source-x64/BSP/MBMx64/OEMInputSamples/TestOEMInput.xml
@@ -54,7 +54,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/Products/MultiLangSample/TestOEMInput.xml
+++ b/Source-x64/Products/MultiLangSample/TestOEMInput.xml
@@ -68,7 +68,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/Products/SampleA/TestOEMInput.xml
+++ b/Source-x64/Products/SampleA/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/Products/SampleB/TestOEMInput.xml
+++ b/Source-x64/Products/SampleB/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x64/Products/SingleLangSample/TestOEMInput.xml
+++ b/Source-x64/Products/SingleLangSample/TestOEMInput.xml
@@ -54,7 +54,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/BSP/CustomMBM/OEMInputSamples/TestOEMInput.xml
+++ b/Source-x86/BSP/CustomMBM/OEMInputSamples/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/BSP/MBM/OEMInputSamples/TestOEMInput.xml
+++ b/Source-x86/BSP/MBM/OEMInputSamples/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/Products/MultiLangSample/TestOEMInput.xml
+++ b/Source-x86/Products/MultiLangSample/TestOEMInput.xml
@@ -68,7 +68,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/Products/SampleA/TestOEMInput.xml
+++ b/Source-x86/Products/SampleA/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/Products/SampleB/TestOEMInput.xml
+++ b/Source-x86/Products/SampleB/TestOEMInput.xml
@@ -53,7 +53,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->

--- a/Source-x86/Products/SingleLangSample/TestOEMInput.xml
+++ b/Source-x86/Products/SingleLangSample/TestOEMInput.xml
@@ -54,7 +54,6 @@
       <Feature>IOT_SSH</Feature>
       <Feature>IOT_SIREP</Feature>
       <!-- Enabling Test images -->
-      <Feature>IOT_DISABLE_UMCI</Feature>
       <Feature>IOT_ENABLE_TESTSIGNING</Feature>
       <Feature>IOT_TOOLKIT</Feature>
       <!-- Debug Features -->


### PR DESCRIPTION
The following deprecated features are removed from the sample oeminput xml files.  The presence of this will not harm the build as they are simply ignored. 

IOT_HWN_CLASS_EXTENSION - this is deprecated as the functionality is now by default in the image.
IOT_DISABLE_UMCI - this is deprecated as the functionality is by default in the image and will need explicit device guard policy to lock down the device.