### PR TITLE
change MMOS MBR partition type back to 0x7

### DIFF
--- a/Common/Packages/DeviceLayout.MBR8GB-R/DeviceLayout.xml
+++ b/Common/Packages/DeviceLayout.MBR8GB-R/DeviceLayout.xml
@@ -31,7 +31,7 @@
       <FileSystem>FAT32</FileSystem>
       <TotalSectors>4096000</TotalSectors>
       <!--MinFreeSectors>6553600</MinFreeSectors-->
-      <Type>0x0C</Type>
+      <Type>0x07</Type>
     </Partition>
  
     <!-- Data Partition  -->


### PR DESCRIPTION
Change to 0x7 so that MMOS junction is restored in restore_junction.cmd