### PR TITLE
Fix drive letter assignment when there is only one drive on the machine

### DIFF
--- a/Tools/GetPartitionInfo.ps1
+++ b/Tools/GetPartitionInfo.ps1
@@ -24,7 +24,8 @@ function GetFreeDriveLetter()
 ################
 
 #getting all the used Drive letters reported by the Operating System
-$drivesinuse = (Get-PSDrive -PSProvider filesystem).Name
+$drivesinuse = @()
+$drivesinuse += (Get-PSDrive -PSProvider filesystem).Name
 $dlxDoc = [xml] (get-content $inputXML);
 Write-Host "PartitionName,ID,Type,TotalSectors,FileSystem,Drive";
 $Partitions = $dlxDoc.GetElementsByTagName("Partition");


### PR DESCRIPTION
Fix drive letter assignment when there is only one drive on the machine say C:\