### PR TITLE
Update MBM bsp to use BYT drivers published by Intel, fixing #269

### DIFF
--- a/Source-x64/BSP/CustomMBMx64/Packages/CustomMBMx64FM.xml
+++ b/Source-x64/BSP/CustomMBMx64/Packages/CustomMBMx64FM.xml
@@ -31,7 +31,7 @@
     <MSFeatureGroups />
     <OEM>
       <!-- Optional Device Drivers -->
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.GPIO.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.GPIO.cab" >
         <FeatureIDs>
           <FeatureID>MBM_X64_GPIO_DRIVER</FeatureID>
         </FeatureIDs>
@@ -42,22 +42,22 @@
           <FeatureID>CustomMBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.UART.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.UART.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.I2C.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.I2C.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.SPI.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.SPI.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.GRFX.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.GFX.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>

--- a/Source-x64/BSP/MBMx64/Packages/MBMx64FM.xml
+++ b/Source-x64/BSP/MBMx64/Packages/MBMx64FM.xml
@@ -32,27 +32,27 @@
     <MSFeatureGroups />
     <OEM>
       <!-- Optional Device Drivers -->
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.GPIO.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.GPIO.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.UART.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.UART.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.I2C.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.I2C.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.SPI.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.SPI.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.MBMx64.GRFX.cab">
+            <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT64.GFX.cab" >
         <FeatureIDs>
           <FeatureID>MBMx64_DRIVERS</FeatureID>
         </FeatureIDs>

--- a/Source-x86/BSP/CustomMBM/Packages/CustomMBMFM.xml
+++ b/Source-x86/BSP/CustomMBM/Packages/CustomMBMFM.xml
@@ -32,7 +32,7 @@
     <MSFeatureGroups />
     <OEM>
       <!-- Optional Device Drivers -->
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.GPIO.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.GPIO.cab" >
         <FeatureIDs>
           <FeatureID>MBM_GPIO_DRIVER</FeatureID>
         </FeatureIDs>
@@ -43,22 +43,22 @@
           <FeatureID>CustomMBM_Drivers</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.UART.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.UART.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.I2C.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.I2C.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.SPI.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.SPI.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.GFX.Build1227.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.GFX.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>

--- a/Source-x86/BSP/MBM/Packages/MBMFM.xml
+++ b/Source-x86/BSP/MBM/Packages/MBMFM.xml
@@ -32,27 +32,27 @@
     <MSFeatureGroups />
     <OEM>
       <!-- Optional Device Drivers -->
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.GPIO.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.GPIO.cab" >
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.UART.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.UART.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.I2C.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.I2C.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.BYT.SPI.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.SPI.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>
       </PackageFile>
-      <PackageFile Path="%BSPPKG_DIR%" Name="Intel.GFX.Build1227.cab">
+      <PackageFile Path="%PKGBLD_DIR%" Name="Intel.BYT.GFX.cab">
         <FeatureIDs>
           <FeatureID>MBM_DRIVERS</FeatureID>
         </FeatureIDs>

--- a/Tools/LaunchTool.cmd
+++ b/Tools/LaunchTool.cmd
@@ -138,7 +138,7 @@ REM Change to Working directory
 cd /D %IOTADK_ROOT%\Tools
 
 doskey /macrofile=alias.txt
-set IOT_ADDON_VERSION=5.3
+set IOT_ADDON_VERSION=5.4
 
 echo IOTADK_ROOT : %IOTADK_ROOT%
 echo ADK_VERSION : %ADK_VERSION%

--- a/Tools/bsptools/BYTx86/convert.cmd
+++ b/Tools/bsptools/BYTx86/convert.cmd
@@ -1,0 +1,52 @@
+@echo off
+
+goto START
+
+:Usage
+echo Usage: convert 
+echo    Generates the wm.xml file for the inf files and renames the existing pkg.xml to _pkg.xml
+echo    [/?].................... Displays this usage string.
+echo    Example:
+echo        convert 
+endlocal
+exit /b 1
+
+:START
+setlocal ENABLEDELAYEDEXPANSION
+if [%BSP_ARCH%] neq [x86] (
+    echo.%CLRRED%Error: Supported only in x86.%CLREND%
+    exit /b 1
+)
+
+set DST_DIR=%BSPSRC_DIR%\BYTx86
+pushd
+cd /D %DST_DIR%
+del /s /q *.wm.xml >nul 2>nul
+dir *.inf /b /s > %DST_DIR%\inflist.txt
+
+for /f "delims=" %%i in (%DST_DIR%\inflist.txt) do (
+    cd %%~pi
+    for %%A in (.) do ( set FILENAME=%%~nxA)
+    move !FILENAME!.pkg.xml !FILENAME!._pkg.xml >nul 2>nul
+    echo Processing %%~nxi 
+    call inf2pkg.cmd %%i !FILENAME! Intel
+)
+
+popd
+del %DST_DIR%\inflist.txt
+
+call convertpkg %DST_DIR%
+
+del /s /q %DST_DIR%\*._pkg.xml >nul 2>nul
+
+echo Fixing the BSPFM.xml file 
+powershell -Command "(gc %DST_DIR%\Packages\BYTx86FM.XML) -replace 'Intel.BYT86.OEM', '%%OEM_NAME%%.BYT86.OEM' -replace 'Intel.BYT86.Device', '%%OEM_NAME%%.BYT86.Device' -replace 'FeatureIdentifierPackage=\"true\"', '' | Out-File %DST_DIR%\Packages\BYTx86FM.xml -Encoding utf8"
+echo Fixing the TestOEMInput.xml file
+powershell -Command "(gc %DST_DIR%\OEMInputSamples\TestOEMInput.xml) -replace '%%BSPSRC_DIR%%', '%%BLD_DIR%%' -replace 'BYTx86\\Packages','MergedFMs' | Out-File %DST_DIR%\OEMInputSamples\TestOEMInput.xml -Encoding utf8"
+echo Fixing the RetailOEMInput.xml file
+powershell -Command "(gc %DST_DIR%\OEMInputSamples\RetailOEMInput.xml) -replace '%%BSPSRC_DIR%%', '%%BLD_DIR%%' -replace 'BYTx86\\Packages','MergedFMs' | Out-File %DST_DIR%\OEMInputSamples\RetailOEMInput.xml -Encoding utf8"
+
+endlocal
+
+echo Conversions done
+exit /b 0


### PR DESCRIPTION
Fixing #269 - Install the latest Intel BYT drivers to build MBM based products