### PR TITLE
Fixed issue on IoTRecovery.ps1

### DIFF
--- a/Tools/IoTCoreImaging/IoTRecovery.ps1
+++ b/Tools/IoTCoreImaging/IoTRecovery.ps1
@@ -111,8 +111,8 @@ function New-IoTWindowsImage {
         $inffiles = (Get-ChildItem -Path $winpeextdrv -Filter "*.inf" -Recurse) | foreach-object {$_.FullName}
         if ($null -ne $inffiles) {
             Publish-Status "Adding drivers"
-            $name = Split-Path $inf -Leaf
             foreach ($inf in $inffiles) {
+                $name = Split-Path $inf -Leaf
                 Write-Verbose "  Adding $name"
                 dism /image:$mountdir /add-driver /driver:$inf
             }


### PR DESCRIPTION
Fixed issue on IoTRecovery.ps1 where variable is used before define causing syntax error when logging.