### PR TITLE
Use newer version of PowerShell rather than preinstalled with windows

### DIFF
--- a/IoTCorePShell.cmd
+++ b/IoTCorePShell.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -Command "Start-Process 'powershell.exe' -ArgumentList '-noexit -ExecutionPolicy Bypass -Command \". %~dp0Tools\Launchshell.ps1\"' -Verb runAs"
+powershell -Command "Start-Process 'pwsh.exe' -ArgumentList '-noexit -ExecutionPolicy Bypass -Command \". %~dp0Tools\Launchshell.ps1\"' -Verb runAs"

--- a/Tools/IoTCoreImaging/IoTWorkspace.ps1
+++ b/Tools/IoTCoreImaging/IoTWorkspace.ps1
@@ -184,7 +184,7 @@ function New-IoTWorkspace {
 function Write-CmdShortcut([string] $dir) {
     $CmdFile = "$dir\IoTCorePShell.cmd"
     Set-Content -Path $CmdFile -Value "@echo off"
-    $cmdstring = "Start-Process 'powershell.exe' -ArgumentList '-noexit -ExecutionPolicy Bypass -Command \`". $env:TOOLS_DIR\Launchshell.ps1\`" %~dp0\IoTWorkspace.xml' -Verb runAs"
+    $cmdstring = "Start-Process 'pwsh.exe' -ArgumentList '-noexit -ExecutionPolicy Bypass -Command \`". $env:TOOLS_DIR\Launchshell.ps1\`" %~dp0\IoTWorkspace.xml' -Verb runAs"
     Add-Content -Path $CmdFile -Value "powershell -Command `"$cmdstring`""
 }
 


### PR DESCRIPTION
powershell.exe replaced with pwsh.exe to take advantage of newer installed versions of PowerShell.
preinstalled edition of PowerShell known to have problems then building FFU.